### PR TITLE
add ability to ignore metadata while creating changesets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.1.2
+Added
+ * implement option to ignore medatata listed in `.forceignore` while creating a changeset by adding the `--exclude-ignored` option
 ## 1.1.1
 Fixed
  * changeset: handle recordType in layoutAssignments of Profile @leboff (#126)

--- a/lib/cli/changeset.js
+++ b/lib/cli/changeset.js
@@ -23,6 +23,7 @@ var doc = "Usage:\n" +
 	"	-d=<directory>               Path to target directory.\n" +
 	"	--dry-run                    Only print what would be done.\n" +
 	"	--ignore-whitespace          Whether to include whitespace when comparing metadata for inclusion/removal.\n" +
+	"	--exclude-ignored            Whether to exclude metadata listed on the .forceIgnore.\n" +
 	"	--destructive                Creates a destructive changeset.\n" +
 	"	-f --force                   Overwrites the target directory if it exists already.";
 
@@ -44,7 +45,8 @@ SubCommand.prototype.process = function(proc, callback) {
 	self.opts = self.docopt();
 	self.name = self.opts['<name>'] || 'foo';
 	var targetBaseDirectory = self.opts['-d'] ? path.resolve(self.opts['-d']) : path.join(self.project.storage.getConfigPath(), 'deployments');
-	self.currentPackageXml = Manifest.fromPackageXml(CliUtils.readFileSafe(self.project.storage.getPackageXmlPath()));
+	var xmlString = CliUtils.readFileSafe(self.project.storage.getPackageXmlPath());
+	self.currentPackageXml = Manifest.fromPackageXml(xmlString);
 	var apiVersion = self.opts['--apiVersion'] || self.currentPackageXml.apiVersion || config.get('defaultApiVersion');
 	// check whether deployment path exists already
 	var deploymentPath = path.resolve(path.join(targetBaseDirectory, self.name));
@@ -65,6 +67,8 @@ SubCommand.prototype.process = function(proc, callback) {
 			console.error('readable not null');
 		}
 	});
+
+	var ignorePatterns = CliUtils.readForceIgnore(self.project.storage.getForceIgnorePath());
 
 	var metadataContainer = new MetadataContainer();
 	self.opts['<metadataFileOrComponentNames>'].forEach(function(componentOrFileName) {
@@ -87,6 +91,13 @@ SubCommand.prototype.process = function(proc, callback) {
 		}
 	});
 
+	if (self.opts['--exclude-ignored']) {
+		if (self.opts['--destructive']) {
+			metadataContainer.destructiveManifest.manifestJSON = Manifest.filterExcludedMetadata(metadataContainer.destructiveManifest.manifestJSON, ignorePatterns);
+		}
+		metadataContainer.manifest.manifestJSON = Manifest.filterExcludedMetadata(metadataContainer.manifest.manifestJSON, ignorePatterns);
+	}
+
 	var stdin = proc.stdin
 		.pipe(split())
 		.pipe(miss.through.obj(function(line, enc, cb) {
@@ -103,7 +114,9 @@ SubCommand.prototype.process = function(proc, callback) {
 		.pipe(Diff.stream({
 			ignoreWhitespace: !!self.opts['--ignore-whitespace']
 		}))
-		.pipe(MetadataContainer.diffStream())
+		.pipe(MetadataContainer.diffStream({
+			ignorePatterns: self.opts['--exclude-ignored'] ? ignorePatterns : null
+		}))
 
 	proc.stdin.on('close', function() {
 		stdin.end();

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -30,6 +30,14 @@ module.exports.fromPackageXml = function(xmlString) {
 	});
 };
 
+module.exports.filterExcludedMetadata = function(components, ignorePatterns) {
+	var matches = _.filter(components, function(component) {
+		return multimatch([component.type + '/' + component.fullName], ignorePatterns).length > 0;
+	});
+	components = _.without.apply(_, [components].concat(matches));
+	return components;
+};
+
 module.exports.fromFetchResult = function(resultJSON) {
 	var fetchResult = new FetchResultParser(resultJSON);
 	return new Manifest({

--- a/lib/metadata-container.js
+++ b/lib/metadata-container.js
@@ -290,7 +290,7 @@ MetadataContainer.prototype.stream = function() {
 };
 
 
-MetadataContainer.diffStream = function() {
+MetadataContainer.diffStream = function(opts) {
 	return miss.through.obj(function(results, enc, cb) {
 		var metadataContainer = new MetadataContainer({
 			vinyls: results.target.vinyls,
@@ -323,6 +323,10 @@ MetadataContainer.diffStream = function() {
 				metadataContainer.manifest.add(to.getComponent());
 			}
 		});
+
+		if (opts.ignorePatterns) {
+			metadataContainer.manifest.manifestJSON = Manifest.filterExcludedMetadata(metadataContainer.manifest.manifestJSON, opts.ignorePatterns);
+		}
 
 		metadataContainer = metadataContainer.filter(metadataContainer.manifest);
 		cb(null, metadataContainer);


### PR DESCRIPTION
implement an option to ignore metadata listed in `.forceignore` while creating a changeset by adding the `--exclude-ignored` option